### PR TITLE
Color chapter: reflect Bootstrap's branding change

### DIFF
--- a/chapters/4-color/index.html
+++ b/chapters/4-color/index.html
@@ -153,7 +153,7 @@
 
                 <h3>Status</h3>
 
-                <p><a href="http://getbootstrap.com">Twitter Bootstrap</a><sup><a href="#cite-8">[8]</a></sup> has popularized the use of <a href="http://getbootstrap.com/css/#helper-classes">status classes</a><sup><a href="#cite-9">[9]</a></sup> which map to certain colors.</p>
+                <p><a href="http://getbootstrap.com">Bootstrap</a><sup><a href="#cite-8">[8]</a></sup> has popularized the use of <a href="http://getbootstrap.com/css/#helper-classes">status classes</a><sup><a href="#cite-9">[9]</a></sup> which map to certain colors.</p>
 
                 <p>Many different apps use this or a similar mapping:</p>
 
@@ -316,8 +316,8 @@
                     <li><a id="cite-5" href="http://littlebigdetails.com/post/35775193711/trello-color-blind-friendly-mode-makes">Little Big Details: Trello - Color Blind Friendly Mode makes labels distinguishable by pattern.</a></li>
                     <li><a id="cite-6" href="http://www.npr.org/2013/01/18/169708761/edward-tufte-wants-you-to-see-better">NPR: Edward Tufte Wants You to See Better</a></li>
                     <li><a id="cite-7" href="https://web.archive.org/web/20070814054750/http://www.colorschemer.com/blog/2007/07/17/why-food-companies-use-red-colors">ColorSchemer (via Archive.org): Why food companies use red colors</a></li>
-                    <li><a id="cite-8" href="http://getbootstrap.com">Twitter Bootstrap</a></li>
-                    <li><a id="cite-9" href="http://getbootstrap.com/css/#helper-classes">Twitter Bootstrap: CSS Helper Classes</a></li>
+                    <li><a id="cite-8" href="http://getbootstrap.com">Bootstrap</a></li>
+                    <li><a id="cite-9" href="http://getbootstrap.com/css/#helper-classes">Bootstrap: CSS Helper Classes</a></li>
                     <li><a id="cite-10" href="http://tympanus.net/codrops/2012/09/17/build-a-color-scheme-the-fundamentals">Codrops: Build a Color Scheme: The Fundamentals</a></li>
                     <li><a id="cite-11" href="http://colorschemedesigner.com/">Color Scheme Designer</a></li>
                     <li><a id="cite-12" href="https://kuler.adobe.com/create/color-wheel/">Adobe Kuler: Color Wheel</a></li>


### PR DESCRIPTION
See http://getbootstrap.com/about/#brand
It's now simply "Bootstrap".
