### PR TITLE
Mozilla bug link replaced with the more exact one

### DIFF
--- a/chapters/3-tables/index.html
+++ b/chapters/3-tables/index.html
@@ -281,7 +281,7 @@
 
                 <p>Yup. You heard me correctly. You go apply <code>position: relative</code> to a table cell, place a <code>position: absolute</code> element inside, and in Firefox, the absolute element will be positioned relative to the earliest positioned parent of the table instead. Bummer.</p>
 
-                <p><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=35168">The bug</a> was reported in 2000.<sup><a href="#cite-6">[6]</a></sup></p>
+                <p><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=63895">The bug</a> was reported in 2000.<sup><a href="#cite-6">[6]</a></sup></p>
 
                 <style>
                     .example-table-gotcha-2 table {
@@ -334,7 +334,7 @@
                     <li><a id="cite-3" href="http://www.hotdesign.com/seybold/everything.html">Seybold Seminars: Why tables for layout is stupid</a></li>
                     <li><a id="cite-4" href="http://coding.smashingmagazine.com/2009/04/08/from-table-hell-to-div-hell/">Smashing Magazine: Table Layouts vs. Div Layouts: From Hell to… Hell?</a></li>
                     <li><a id="cite-5" href="http://www.vanseodesign.com/css/tables/">Vaneso Design: Are CSS Tables Better Than HTML Tables?</a></li>
-                    <li><a id="cite-6" href="https://bugzilla.mozilla.org/show_bug.cgi?id=35168">Mozilla Bugzilla: relative positioning of table cells doesn’t work</a></li>
+                    <li><a id="cite-6" href="https://bugzilla.mozilla.org/show_bug.cgi?id=63895">Mozilla Bugzilla: positioned internal table elements not abs pos containing block</a></li>
                 </ol>
 
                 <hr>


### PR DESCRIPTION
The Mozilla bug referenced in the text is not about absolute positioning _in_ the cells, but about relative positioning of _the cells themselves._ Shouldn't this reference be replaced with the link to the bug that is specifically about positioning _in_ the cells?

Also, both these Mozilla bugs have been fixed in 2014. Shouldn't it be mentioned in the text?
